### PR TITLE
First functional implementation

### DIFF
--- a/launch/yapykaldi_hmi.launch
+++ b/launch/yapykaldi_hmi.launch
@@ -9,7 +9,7 @@
         <node name="string_topic_answerer" pkg="hmi" type="string_topic_answerer" output="$(arg output)"/>
 
         <node name="yapykaldi_hmi_node" pkg="yapykaldi_ros" type="yapykaldi_hmi_node" output="$(arg output)">
-            <param name="~/model_dir" value="~/git/kaldi/data/kaldi-generic-en-tdnn_fl-latest"/>
+            <param name="~/model_dir" value="~/git/yapykaldi/data/kaldi-generic-en-tdnn_fl-latest"/>
         </node>
 
     </group> <!-- ns="hmi" -->

--- a/launch/yapykaldi_hmi.launch
+++ b/launch/yapykaldi_hmi.launch
@@ -1,13 +1,16 @@
 <?xml version="1.0"?>
 <launch>
+    <arg name="output" value="screen" />
 
     <!-- Always run a multicast server with a string topic answerer -->
     <node name="hmi" pkg="hmi" type="multi_client" output="$(arg output)"/>
 
     <group ns="hmi">
-        <node name="string_topic_answerer" pkg="hmi" type="string_topic_answerer" output="log"/>
+        <node name="string_topic_answerer" pkg="hmi" type="string_topic_answerer" output="$(arg output)"/>
 
-        <node name="yapykaldi_hmi_node" pkg="yapykaldi_ros" type="yapykaldi_hmi_node" output="log"/>
+        <node name="yapykaldi_hmi_node" pkg="yapykaldi_ros" type="yapykaldi_hmi_node" output="$(arg output)">
+            <param name="~/model_dir" value="~/git/kaldi/data/kaldi-generic-en-tdnn_fl-latest"/>
+        </node>
 
     </group> <!-- ns="hmi" -->
 

--- a/scripts/yapykaldi_hmi_node
+++ b/scripts/yapykaldi_hmi_node
@@ -6,7 +6,6 @@ import rospy
 from yapykaldi_ros import HMIServerYapykaldi
 
 if __name__ == "__main__":
-
     rospy.init_node('yapykaldi_hmi_node')
     rospy.loginfo("Creating HMIServerYapykaldi")
     c = HMIServerYapykaldi()

--- a/scripts/yapykaldi_hmi_node
+++ b/scripts/yapykaldi_hmi_node
@@ -5,9 +5,17 @@
 import rospy
 from yapykaldi_ros import HMIServerYapykaldi
 
-
 if __name__ == "__main__":
 
     rospy.init_node('yapykaldi_hmi_node')
     rospy.loginfo("Creating HMIServerYapykaldi")
     c = HMIServerYapykaldi()
+
+    rospy.loginfo("Registering HMIServerYapykaldi shutdown hook")
+
+    def shutdown():
+        rospy.loginfo("Shutting down HMIServerYapykaldi")
+        c.stop()
+
+    rospy.on_shutdown(shutdown)
+    rospy.loginfo("Registered HMIServerYapykaldi shutdown hook")

--- a/scripts/yapykaldi_hmi_node
+++ b/scripts/yapykaldi_hmi_node
@@ -11,11 +11,12 @@ if __name__ == "__main__":
     rospy.loginfo("Creating HMIServerYapykaldi")
     c = HMIServerYapykaldi()
 
-    rospy.loginfo("Registering HMIServerYapykaldi shutdown hook")
+    rospy.logdebug("Registering HMIServerYapykaldi shutdown hook")
 
     def shutdown():
         rospy.loginfo("Shutting down HMIServerYapykaldi")
         c.stop()
 
     rospy.on_shutdown(shutdown)
-    rospy.loginfo("Registered HMIServerYapykaldi shutdown hook")
+    rospy.logdebug("Registered HMIServerYapykaldi shutdown hook")
+    rospy.spin()

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -3,7 +3,6 @@ from hmi import AbstractHMIServer, HMIResult
 from hmi.common import parse_sentence, verify_grammar
 import os
 import rospy
-from std_msgs.msg import String
 from threading import Event
 from yapykaldi.asr import Asr
 from yapykaldi.audio_handling.sources import WaveFileSource, PyAudioMicrophoneSource

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -1,7 +1,9 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from hmi import AbstractHMIServer, HMIResult
+from hmi.common import parse_sentence
 import os
 import rospy
+from std_msgs.msg import String
 from yapykaldi.asr import Asr
 
 
@@ -14,6 +16,17 @@ class HMIServerYapykaldi(AbstractHMIServer):
                         model_type=rospy.get_param('~model_type', 'nnet3'),
                         output_dir=rospy.get_param('~output_dir', '/tmp/hmi_server_yapykaldi'))
 
+        self._asr.register_callback(self.string_recognized_callback)
+
+        self._string = ""
+
+    def stop(self):
+        rospy.loginfo("Stopping {}".format(self))
+        self._asr.stop()
+
+    def string_recognized_callback(self, string):
+        self._string = string  # Using a threading primitive for this would be nicer!
+
     def _determine_answer(self, description, grammar, target, is_preempt_requested):
         """
         Method override to start speech recognition upon receiving a query
@@ -24,3 +37,25 @@ class HMIServerYapykaldi(AbstractHMIServer):
         :param target: (str) target that should be obtained from the grammar
         :param is_preempt_requested: (callable) checks whether a preempt is requested by the hmi client
         """
+        rospy.loginfo("Need an answer from ASR!")
+        self._string = None
+        while not rospy.is_shutdown() and not is_preempt_requested() and not self._string:
+            rospy.loginfo("Sleep")
+            rospy.sleep(.1)
+
+        if rospy.is_shutdown() or is_preempt_requested():
+            rospy.loginfo("Stop")
+            self._asr.stop()
+            return None
+
+        rospy.loginfo("Received string: '%s'", self._string)
+
+        semantics = parse_sentence(self._string, grammar, target)
+
+        rospy.loginfo("Parsed semantics: %s", semantics)
+
+        result = HMIResult(self._string, semantics)
+        self._asr.stop()
+        self._string = None
+
+        return result

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -6,6 +6,7 @@ import rospy
 from threading import Event
 from yapykaldi.asr import Asr
 from yapykaldi.io import WaveFileSource, PyAudioMicrophoneSource, WaveFileSink
+from yapykaldi.logger import LOGGER_NAME as YAPYKALDI_LOGGER_NAME
 
 from .rospy_logging import route_logger_to_ros
 
@@ -14,7 +15,7 @@ class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
 
-        # route_logger_to_ros('yapykaldi')
+        # route_logger_to_ros('YAPYKALDI_LOGGER_NAME')
         # self.stream = WaveFileSource("/home/loy/output.wav")
         rospy.loginfo("Creating audio stream")
         self._source = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from hmi import AbstractHMIServer, HMIResult
 from hmi.common import parse_sentence, verify_grammar
-import logging
 import os
 import rospy
 from threading import Event
@@ -9,19 +8,14 @@ from yapykaldi.asr import Asr
 from yapykaldi.audio_handling.sources import WaveFileSource, PyAudioMicrophoneSource
 from yapykaldi.audio_handling.sinks import WaveFileSink
 
-from .rospy_logging import RospyLogHandler
-
-rpl = RospyLogHandler()
-rpl.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-root = logging.getLogger()
-root.setLevel(logging.DEBUG)
-root.addHandler(rpl)
+from .rospy_logging import route_logger_to_ros
 
 
 class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
 
+        route_logger_to_ros('yapykaldi')
         # self.stream = WaveFileSource("/home/loy/output.wav")
         rospy.loginfo("Creating audio stream")
         self.stream = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -1,14 +1,18 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
-from builtins import *
-import rospy
-from yapykaldi import Asr
 from hmi import AbstractHMIServer, HMIResult
+import os
+import rospy
+from yapykaldi.asr import Asr
 
 
 class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
-        super().__init__(rospy.get_name())
+        super(HMIServerYapykaldi, self).__init__(rospy.get_name())
+
+        self._asr = Asr(model_dir=os.path.expanduser(rospy.get_param('~model_dir')),
+                        model_type=rospy.get_param('~model_type', 'nnet3'),
+                        output_dir=rospy.get_param('~output_dir', '/tmp/hmi_server_yapykaldi'))
 
     def _determine_answer(self, description, grammar, target, is_preempt_requested):
         """

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -4,13 +4,17 @@ from hmi.common import parse_sentence, verify_grammar
 import os
 import rospy
 from std_msgs.msg import String
-from yapykaldi.asr import Asr, WaveFileStreamer
+from threading import Event
+from yapykaldi.asr import Asr
+from yapykaldi.audio_handling.sources import WaveFileSource, PyAudioMicrophoneSource
+from yapykaldi.audio_handling.sinks import WaveFileSink
 
 
 class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
-        stream = WaveFileStreamer("/home/loy/output.wav")
+        # stream = WaveFileSource("/home/loy/output.wav")
+        stream = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))
         rospy.loginfo("Setting up ASR, may take a while...")
         self._asr = Asr(model_dir=os.path.expanduser(rospy.get_param('~model_dir')),
                         model_type=rospy.get_param('~model_type', 'nnet3'),

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -1,33 +1,44 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from hmi import AbstractHMIServer, HMIResult
-from hmi.common import parse_sentence
+from hmi.common import parse_sentence, verify_grammar
 import os
 import rospy
 from std_msgs.msg import String
-from yapykaldi.asr import Asr
+from yapykaldi.asr import Asr, WaveFileStreamer
 
 
 class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
-        super(HMIServerYapykaldi, self).__init__(rospy.get_name())
-
+        stream = WaveFileStreamer("/home/loy/output.wav")
+        rospy.loginfo("Setting up ASR, may take a while...")
         self._asr = Asr(model_dir=os.path.expanduser(rospy.get_param('~model_dir')),
                         model_type=rospy.get_param('~model_type', 'nnet3'),
-                        output_dir=rospy.get_param('~output_dir', '/tmp/hmi_server_yapykaldi'))
+                        stream=stream)
+        rospy.loginfo("Set up ASR")
 
-        self._asr.register_callback(self.string_recognized_callback)
+        self._asr.register_fully_recognized_callback(self.string_fully_recognized_callback)
+        self._asr.register_partially_recognized_callback(self.string_partially_recognized_callback)
 
         self._string = ""
+
+        super(HMIServerYapykaldi, self).__init__(rospy.get_name())
 
     def stop(self):
         rospy.loginfo("Stopping {}".format(self))
         self._asr.stop()
 
-    def string_recognized_callback(self, string):
-        self._string = string  # Using a threading primitive for this would be nicer!
+    def string_fully_recognized_callback(self, string):
+        # type: (str) -> None
+        rospy.loginfo("Got a string: '{}'".format(string))
+        self._string = string.strip()  # Using a threading primitive for this would be nicer!
+
+    def string_partially_recognized_callback(self, string):
+        # type: (str) -> None
+        rospy.loginfo("Got an intermediate result string: '{}'".format(string))
 
     def _determine_answer(self, description, grammar, target, is_preempt_requested):
+        # type: (str, str, str, Func) -> None
         """
         Method override to start speech recognition upon receiving a query
         from the HMI server
@@ -37,10 +48,15 @@ class HMIServerYapykaldi(AbstractHMIServer):
         :param target: (str) target that should be obtained from the grammar
         :param is_preempt_requested: (callable) checks whether a preempt is requested by the hmi client
         """
-        rospy.loginfo("Need an answer from ASR!")
+        rospy.loginfo("Need an answer from ASR for '{}'".format(description))
         self._string = None
+
+        verify_grammar(grammar)
+
+        self._asr.start()
+
         while not rospy.is_shutdown() and not is_preempt_requested() and not self._string:
-            rospy.loginfo("Sleep")
+            rospy.logdebug("Sleep")
             rospy.sleep(.1)
 
         if rospy.is_shutdown() or is_preempt_requested():

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -28,8 +28,8 @@ class HMIServerYapykaldi(AbstractHMIServer):
                         stream=self._source)
         rospy.loginfo("Set up ASR")
 
-        self._asr.register_fully_recognized_callback(self.string_fully_recognized_callback)
-        self._asr.register_partially_recognized_callback(self.string_partially_recognized_callback)
+        self._asr.register_callback(self.string_fully_recognized_callback)
+        self._asr.register_callback(self.string_partially_recognized_callback, partial=True)
 
         self._partial_string = ""
         self._completed_string = ""

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -46,14 +46,16 @@ class HMIServerYapykaldi(AbstractHMIServer):
 
     def string_fully_recognized_callback(self, string):
         # type: (str) -> None
-        rospy.loginfo("Got a string: '{}'".format(string))
+        rospy.loginfo("Got a complete string: '{}'".format(string))
         self._completed_string = string.strip()  # Using a threading primitive for this would be nicer!
 
     def _voice_timer_elapsed(self, *args):
         if not self._completed_string:
-            rospy.loginfo("Voice timer elapsed after not hearing something ew in a while")
+            rospy.loginfo("Voice timer elapsed after not hearing something new in a while, "
+                          "stopping ASR")
         else:
-            rospy.logdebug("Voice timer elapsed after not hearing something ew in a while")
+            rospy.logdebug("Voice timer elapsed after not hearing something new in a while, "
+                           "stopping ASR")
 
         self._asr.stop()
         self._completed_string = self._partial_string

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -5,8 +5,7 @@ import os
 import rospy
 from threading import Event
 from yapykaldi.asr import Asr
-from yapykaldi.audio_handling.sources import WaveFileSource, PyAudioMicrophoneSource
-from yapykaldi.audio_handling.sinks import WaveFileSink
+from yapykaldi.io import WaveFileSource, PyAudioMicrophoneSource, WaveFileSink
 
 from .rospy_logging import route_logger_to_ros
 

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -22,10 +22,12 @@ class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
 
-        self.stream = WaveFileSource("/home/loy/output.wav")
-        # self.stream = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))
+        # self.stream = WaveFileSource("/home/loy/output.wav")
+        rospy.loginfo("Creating audio stream")
+        self.stream = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))
         rospy.loginfo("Opening audio stream")
         self.stream.open()
+
         rospy.loginfo("Setting up ASR, may take a while...")
         self._asr = Asr(model_dir=os.path.expanduser(rospy.get_param('~model_dir')),
                         model_type=rospy.get_param('~model_type', 'nnet3'),
@@ -46,6 +48,7 @@ class HMIServerYapykaldi(AbstractHMIServer):
     def stop(self):
         rospy.loginfo("Stopping {}".format(self))
         self._asr.stop()
+        self.stream.close()
 
     def string_fully_recognized_callback(self, string):
         # type: (str) -> None
@@ -104,6 +107,8 @@ class HMIServerYapykaldi(AbstractHMIServer):
         verify_grammar(grammar)
 
         self._asr.start()
+
+        self._asr.recognize()
 
         while not rospy.is_shutdown() and \
                 not is_preempt_requested() and \

--- a/src/yapykaldi_ros/hmi_server_yapykaldi.py
+++ b/src/yapykaldi_ros/hmi_server_yapykaldi.py
@@ -15,7 +15,7 @@ class HMIServerYapykaldi(AbstractHMIServer):
     """HMI server wrapper yapykaldi ASR app"""
     def __init__(self):
 
-        # route_logger_to_ros('YAPYKALDI_LOGGER_NAME')
+        # route_logger_to_ros(YAPYKALDI_LOGGER_NAME)
         # self.stream = WaveFileSource("/home/loy/output.wav")
         rospy.loginfo("Creating audio stream")
         self._source = PyAudioMicrophoneSource(saver=WaveFileSink("/tmp/recording.wav"))

--- a/src/yapykaldi_ros/rospy_logging.py
+++ b/src/yapykaldi_ros/rospy_logging.py
@@ -2,18 +2,33 @@ import logging
 import rospy
 
 
-class RospyLogHandler(logging.Handler):
-    def __init__(self, *args, **kwargs):
-        super(RospyLogHandler, self).__init__(*args, **kwargs)
+class ConnectPythonLoggingToROS(logging.Handler):
 
-        self._mapping = {
-            logging.INFO: rospy.loginfo,
-            logging.DEBUG: rospy.logdebug,
-            logging.WARN: rospy.logwarn,
-            logging.ERROR: rospy.logerr,
-        }
+    level_map = {
+        logging.DEBUG: rospy.logdebug,
+        logging.INFO: rospy.loginfo,
+        logging.WARNING: rospy.logwarn,
+        logging.ERROR: rospy.logerr,
+        logging.CRITICAL: rospy.logfatal
+    }
 
     def emit(self, record):
-        # type (logging.LogRecord) -> None
-        rospy_log = self._mapping[record.level]
-        rospy_log(record.msg)
+        try:
+            self.level_map[record.levelno]("%s: %s" % (record.name, record.msg))
+        except KeyError:
+            rospy.logerr("unknown log level %s LOG: %s: %s" % (record.levelno, record.name, record.msg))
+
+
+def route_logger_to_ros(logger_name):
+    """
+    Re-routes a Python logging.logger to the ROS logging infrastructure.
+    Without using this, once `rospy.init_node()` has been called, any use of `logging` occurs silently.
+
+    Usage:
+        rospy.init_node('my_node')
+        route_logger_to_ros('my_custom_library')
+        # In an imported library:
+        logger = logging.getLogger('my_custom_library)
+        logger.info('This message gets routed to ROS logging if a ROS node was initialized in this process.')
+    """
+    logging.getLogger(logger_name).addHandler(ConnectPythonLoggingToROS())

--- a/src/yapykaldi_ros/rospy_logging.py
+++ b/src/yapykaldi_ros/rospy_logging.py
@@ -1,0 +1,19 @@
+import logging
+import rospy
+
+
+class RospyLogHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        super(RospyLogHandler, self).__init__(*args, **kwargs)
+
+        self._mapping = {
+            logging.INFO: rospy.loginfo,
+            logging.DEBUG: rospy.logdebug,
+            logging.WARN: rospy.logwarn,
+            logging.ERROR: rospy.logerr,
+        }
+
+    def emit(self, record):
+        # type (logging.LogRecord) -> None
+        rospy_log = self._mapping[record.level]
+        rospy_log(record.msg)


### PR DESCRIPTION
Depends on:
- https://github.com/tue-robotics/yapykaldi/pull/1/
- https://github.com/tue-robotics/kaldi.git 

To test this:
- Either [setup audio loopback](https://unix.stackexchange.com/questions/82259/how-to-pipe-audio-output-to-mic-input) or speak at the appropriate time
- `roslaunch yapykaldi_ros yapykaldi_hmi.launch`
- `rosrun hmi test_query --grammar-file=orders.fcfg O`  # See attached file, from https://github.com/tue-robotics/grammar_parser/blob/master/README.md
- `aplay output.wav` (see attached file, me saying "Can I have  coke?")

[ordering.zip](https://github.com/tue-robotics/yapykaldi_ros/files/4821417/ordering.zip)

TODO:

- [x] Recording still is not working OK, recording a 2nd time crashes :cry: Mostly due to my botched implementation of the `PyaudioMicrophoneSource` in `yapykaldi`
- [ ] Voice Activity detection to stop listening at the right time

